### PR TITLE
feat: Query E820 memory map (closes #1)

### DIFF
--- a/boot.asm
+++ b/boot.asm
@@ -26,7 +26,21 @@ start:
     db 'PSOS BOOT ' ; Volume label
     db 'FAT12   ' ; Filesystem type
 
+; Write a single character directly to VGA text mode (0xB800:offset).
+; Uses GS as the VGA segment — set once at the top of start_boot and
+; left alone so it can be used anywhere without disturbing DS/ES.
+; Attribute 0x4F = white text on red background (hard to miss).
+%macro trace 2          ; trace char, vga_byte_offset
+    mov byte [gs:%2],   %1
+    mov byte [gs:%2+1], 0x4F
+%endmacro
+
 start_boot:
+    ; Point GS at the VGA text buffer for debug breadcrumbs.
+    mov ax, 0xB800
+    mov gs, ax
+    trace '?', 0        ; '?' = we reached start_boot
+
     ; Normalise segments and establish an explicit stack.
     ; Loading SS inhibits interrupts for the following instruction (SP load),
     ; guaranteeing an atomic SS:SP update.
@@ -36,6 +50,8 @@ start_boot:
     mov ss, ax
     mov sp, 0x7C00      ; stack grows down from boot sector base
 
+    trace '1', 2        ; '1' = segments + stack set up
+
     ; --- E820 memory map query ---
     ; Layout: dword entry count at 0x500, then 24-byte entries from 0x504.
     ; 24 bytes = 8 (base) + 8 (length) + 4 (type) + 4 (ACPI 3.0 attrs).
@@ -43,6 +59,7 @@ start_boot:
     mov dword [0x500], 0    ; initialise entry count
     mov di, 0x504           ; ES:DI = 0x0000:0x504 (ES=0 set above)
     xor ebx, ebx            ; EBX=0 starts the E820 enumeration
+    trace '2', 4        ; '2' = about to call int 0x15/E820
 
 .e820_loop:
     mov eax, 0xE820
@@ -58,6 +75,7 @@ start_boot:
     jnz .e820_loop
 
 .e820_done:
+    trace '3', 6        ; '3' = E820 done, about to load stage2
 
     ; Re-zero AX and ES: the BIOS E820 handler may have clobbered them.
     xor ax, ax
@@ -72,6 +90,7 @@ start_boot:
     ; dl is the drive number, passed by the BIOS
     mov bx, 0x8000 ; ES:BX load address (ES=0 set above)
     int 0x13
+    trace '4', 8        ; '4' = int 0x13 returned (stage2 should be loaded)
 
     jmp 0x0000:0x8000 ; Far jump to normalise CS=0 before stage2
 

--- a/boot.asm
+++ b/boot.asm
@@ -27,10 +27,14 @@ start:
     db 'FAT12   ' ; Filesystem type
 
 start_boot:
-    ; Normalise segments so ES:BX and the subsequent far jump are reliable
+    ; Normalise segments and establish an explicit stack.
+    ; Loading SS inhibits interrupts for the following instruction (SP load),
+    ; guaranteeing an atomic SS:SP update.
     xor ax, ax
     mov ds, ax
     mov es, ax
+    mov ss, ax
+    mov sp, 0x7C00      ; stack grows down from boot sector base
 
     ; --- E820 memory map query ---
     ; Layout: dword entry count at 0x500, then 24-byte entries from 0x504.
@@ -54,6 +58,10 @@ start_boot:
     jnz .e820_loop
 
 .e820_done:
+
+    ; Re-zero AX and ES: the BIOS E820 handler may have clobbered them.
+    xor ax, ax
+    mov es, ax
 
     ; Load stage2 from disk
     mov ah, 0x02 ; Read sectors

--- a/boot.asm
+++ b/boot.asm
@@ -32,6 +32,29 @@ start_boot:
     mov ds, ax
     mov es, ax
 
+    ; --- E820 memory map query ---
+    ; Layout: dword entry count at 0x500, then 24-byte entries from 0x504.
+    ; 24 bytes = 8 (base) + 8 (length) + 4 (type) + 4 (ACPI 3.0 attrs).
+    ; Must be done in real mode before the protected-mode switch.
+    mov dword [0x500], 0    ; initialise entry count
+    mov di, 0x504           ; ES:DI = 0x0000:0x504 (ES=0 set above)
+    xor ebx, ebx            ; EBX=0 starts the E820 enumeration
+
+.e820_loop:
+    mov eax, 0xE820
+    mov ecx, 24             ; request 24-byte (ACPI 3.0) entries
+    mov edx, 0x534D4150     ; signature 'SMAP'
+    int 0x15
+    jc .e820_done           ; carry set: end of list or unsupported
+    cmp eax, 0x534D4150     ; BIOS must echo 'SMAP' back in EAX
+    jne .e820_done
+    inc dword [0x500]       ; one more valid entry
+    add di, 24              ; advance buffer pointer
+    test ebx, ebx           ; EBX=0 after last entry
+    jnz .e820_loop
+
+.e820_done:
+
     ; Load stage2 from disk
     mov ah, 0x02 ; Read sectors
     mov al, 4    ; Number of sectors to read

--- a/boot.asm
+++ b/boot.asm
@@ -56,12 +56,17 @@ start_boot:
     ; Layout: dword entry count at 0x500, then 24-byte entries from 0x504.
     ; 24 bytes = 8 (base) + 8 (length) + 4 (type) + 4 (ACPI 3.0 attrs).
     ; Must be done in real mode before the protected-mode switch.
+    ; Buffer capacity: (0x7C00 - 0x504) / 24 = 1269 max; cap at 128 for safety.
+    push dx                 ; save boot drive number: the loop sets EDX=0x534D4150
+                            ; (DL='P') on every iteration, clobbering DL before int 0x13
     mov dword [0x500], 0    ; initialise entry count
     mov di, 0x504           ; ES:DI = 0x0000:0x504 (ES=0 set above)
     xor ebx, ebx            ; EBX=0 starts the E820 enumeration
     trace '2', 4        ; '2' = about to call int 0x15/E820
 
 .e820_loop:
+    cmp dword [0x500], 128  ; cap at 128 entries to protect the boot sector
+    jae .e820_done
     mov eax, 0xE820
     mov ecx, 24             ; request 24-byte (ACPI 3.0) entries
     mov edx, 0x534D4150     ; signature 'SMAP'
@@ -80,6 +85,7 @@ start_boot:
     ; Re-zero AX and ES: the BIOS E820 handler may have clobbered them.
     xor ax, ax
     mov es, ax
+    pop dx                  ; restore boot drive number (saved before E820 loop)
 
     ; Load stage2 from disk
     mov ah, 0x02 ; Read sectors
@@ -87,7 +93,7 @@ start_boot:
     mov ch, 0    ; Cylinder
     mov cl, 2    ; Sector to start reading from (1 is the boot sector)
     mov dh, 0    ; Head
-    ; dl is the drive number, passed by the BIOS
+    ; dl = boot drive number, restored above
     mov bx, 0x8000 ; ES:BX load address (ES=0 set above)
     int 0x13
     trace '4', 8        ; '4' = int 0x13 returned (stage2 should be loaded)

--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -29,5 +29,9 @@ echo "Writing stage2 to image..."
 dd if=stage2.bin of=psos.img seek=1 bs=512 conv=notrunc
 
 # 7. Run in QEMU
+# -no-reboot  : freeze on triple fault instead of reset-looping
+# -monitor stdio : type 'info registers' in this terminal when hung
 echo "Booting PSOS in QEMU..."
-qemu-system-x86_64 -k en-gb -drive file=psos.img,format=raw
+echo "Tip: type 'info registers' here when the screen hangs"
+qemu-system-x86_64 -k en-gb -drive file=psos.img,format=raw \
+    -no-reboot -monitor stdio

--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -33,5 +33,7 @@ dd if=stage2.bin of=psos.img seek=1 bs=512 conv=notrunc
 # -monitor stdio : type 'info registers' in this terminal when hung
 echo "Booting PSOS in QEMU..."
 echo "Tip: type 'info registers' here when the screen hangs"
+echo "     interrupt log written to /tmp/qemu.log"
 qemu-system-x86_64 -k en-gb -drive file=psos.img,format=raw \
-    -no-reboot -monitor stdio
+    -no-reboot -monitor stdio \
+    -d int -D /tmp/qemu.log

--- a/stage2.asm
+++ b/stage2.asm
@@ -36,6 +36,8 @@ protected_mode:
     mov ah, 0x17
     rep stosw
 
+    call print_e820_map
+
     mov edi, (5 * 80 + 25) * 2
     mov esi, ascii_art_line1
     call print_string_pm
@@ -262,6 +264,62 @@ to_hex_char:
 .is_digit:
     add al, '0'
     ret
+
+; --- E820 memory map (written by boot.asm before PM switch) ---
+E820_COUNT   equ 0x500   ; dword: number of entries
+E820_ENTRIES equ 0x504   ; array of 24-byte entries:
+                         ;   +0  qword base address
+                         ;   +8  qword length
+                         ;   +16 dword type (1=usable,2=reserved,3=ACPI,4=NVS,5=bad)
+                         ;   +20 dword ACPI 3.0 extended attributes
+
+; print_e820_map
+; Reads the E820 map left by the bootloader and prints each entry to VGA.
+; Rows 0..(count-1), format: "BASE=XXXXXXXX LEN=XXXXXXXX TYPE=X"
+; Clobbers: eax, ebx, ecx, edx, esi, edi
+print_e820_map:
+    mov ecx, [E820_COUNT]
+    test ecx, ecx
+    jz .done
+
+    mov ebx, E820_ENTRIES   ; pointer to current entry
+    xor edx, edx            ; row counter
+
+.entry_loop:
+    ; Print "BASE=XXXXXXXX LEN=XXXXXXXX TYPE=XXXXXXXX"
+    ; edi is the VGA byte offset; print_string_pm advances it,
+    ; but print_hex uses pushad/popad so edi must be manually advanced
+    ; by 8*2=16 after each print_hex call.
+    mov edi, edx
+    imul edi, 80 * 2        ; start of row
+
+    mov esi, msg_e820_base
+    call print_string_pm    ; edi now past "BASE="
+    mov eax, [ebx]          ; base low 32 bits
+    call print_hex
+    add edi, 8 * 2          ; advance past 8 hex digits
+
+    mov esi, msg_e820_len
+    call print_string_pm    ; edi now past " LEN="
+    mov eax, [ebx + 8]      ; length low 32 bits
+    call print_hex
+    add edi, 8 * 2
+
+    mov esi, msg_e820_type
+    call print_string_pm    ; edi now past " TYPE="
+    mov eax, [ebx + 16]     ; type
+    call print_hex
+
+    inc edx
+    add ebx, 24
+    loop .entry_loop
+
+.done:
+    ret
+
+msg_e820_base db 'BASE=', 0
+msg_e820_len  db ' LEN=', 0
+msg_e820_type db ' TYPE=', 0
 
 ; FAT12 Boot Sector Structure
 struc fat12_bpb

--- a/stage2.asm
+++ b/stage2.asm
@@ -286,27 +286,35 @@ print_e820_map:
     xor edx, edx            ; row counter
 
 .entry_loop:
-    ; Print "BASE=XXXXXXXX LEN=XXXXXXXX TYPE=XXXXXXXX"
-    ; edi is the VGA byte offset; print_string_pm advances it,
-    ; but print_hex uses pushad/popad so edi must be manually advanced
-    ; by 8*2=16 after each print_hex call.
+    ; print_string_pm clobbers EBX (sets it to 0xb8000), so push/pop it
+    ; around every call to keep the entry pointer intact.
+    ; print_hex uses pushad/popad so it preserves EBX automatically.
+    ; edi is the VGA byte offset; print_string_pm advances it per char,
+    ; but print_hex does not — manually add 8*2 after each print_hex.
+
     mov edi, edx
     imul edi, 80 * 2        ; start of row
 
+    push ebx
     mov esi, msg_e820_base
     call print_string_pm    ; edi now past "BASE="
+    pop ebx
     mov eax, [ebx]          ; base low 32 bits
     call print_hex
     add edi, 8 * 2          ; advance past 8 hex digits
 
+    push ebx
     mov esi, msg_e820_len
     call print_string_pm    ; edi now past " LEN="
+    pop ebx
     mov eax, [ebx + 8]      ; length low 32 bits
     call print_hex
     add edi, 8 * 2
 
+    push ebx
     mov esi, msg_e820_type
     call print_string_pm    ; edi now past " TYPE="
+    pop ebx
     mov eax, [ebx + 16]     ; type
     call print_hex
 

--- a/stage2.asm
+++ b/stage2.asm
@@ -15,20 +15,34 @@ start_stage2:
     mov cr0, eax
     jmp 0x08:protected_mode
 
+; Write a single VGA character (white on blue, 0x1F) directly via a flat
+; DS write. Only safe after DS has been loaded with the flat descriptor.
+; col is a byte column index; the byte offset is col*2.
+%macro pm_trace 2       ; pm_trace char, col
+    mov byte [0xb8000 + %2 * 2],     %1
+    mov byte [0xb8000 + %2 * 2 + 1], 0x1F
+%endmacro
+
 bits 32
 protected_mode:
     mov ax, 0x10
-    mov ds, ax
+    mov ds, ax          ; flat data segment — now safe to write anywhere
     mov es, ax
     mov fs, ax
     mov gs, ax
     mov ss, ax
     mov esp, stack_top
+    pm_trace 'A', 10    ; col 10: segments + stack set up
 
     call pic_remap
+    pm_trace 'B', 11    ; col 11: PIC remapped
+
     call idt_setup
     lidt [idt_descriptor]
+    pm_trace 'C', 12    ; col 12: IDT loaded
+
     sti
+    pm_trace 'D', 13    ; col 13: interrupts enabled
 
     mov edi, 0xb8000
     mov ecx, 80 * 25

--- a/stage2.asm
+++ b/stage2.asm
@@ -8,6 +8,12 @@ start_stage2:
     xor ax, ax
     mov ds, ax
 
+    ; Real-mode breadcrumb: confirm stage2 is actually loaded and running.
+    ; GS is still 0xB800 from boot.asm (never cleared in stage2), so
+    ; [GS:col*2] writes directly into the VGA text buffer without touching DS.
+    mov byte [gs:5*2],   '5'    ; col 5 = stage2 reached real-mode entry
+    mov byte [gs:5*2+1], 0x4F   ; white on red, same as boot.asm trace chars
+
     cli
     lgdt [gdt_descriptor]
     mov eax, cr0
@@ -289,7 +295,7 @@ E820_ENTRIES equ 0x504   ; array of 24-byte entries:
 
 ; print_e820_map
 ; Reads the E820 map left by the bootloader and prints each entry to VGA.
-; Rows 0..(count-1), format: "BASE=XXXXXXXX LEN=XXXXXXXX TYPE=X"
+; Rows 0..(count-1), format: "BASE=XXXXXXXXXXXXXXXX LEN=XXXXXXXXXXXXXXXX TYPE=XXXXXXXX"
 ; Clobbers: eax, ebx, ecx, edx, esi, edi
 print_e820_map:
     mov ecx, [E820_COUNT]
@@ -313,17 +319,23 @@ print_e820_map:
     mov esi, msg_e820_base
     call print_string_pm    ; edi now past "BASE="
     pop ebx
+    mov eax, [ebx + 4]      ; base high 32 bits
+    call print_hex
+    add edi, 8 * 2
     mov eax, [ebx]          ; base low 32 bits
     call print_hex
-    add edi, 8 * 2          ; advance past 8 hex digits
+    add edi, 8 * 2          ; advance past 16 hex digits total
 
     push ebx
     mov esi, msg_e820_len
     call print_string_pm    ; edi now past " LEN="
     pop ebx
-    mov eax, [ebx + 8]      ; length low 32 bits
+    mov eax, [ebx + 12]     ; length high 32 bits
     call print_hex
     add edi, 8 * 2
+    mov eax, [ebx + 8]      ; length low 32 bits
+    call print_hex
+    add edi, 8 * 2          ; advance past 16 hex digits total
 
     push ebx
     mov esi, msg_e820_type


### PR DESCRIPTION
## Summary

- Query the BIOS E820 memory map in real mode before the protected-mode switch
- Display all entries (64-bit base, 64-bit length, 32-bit type) in VGA text mode
- Fix DL clobber: save/restore boot drive number across E820 loop (`push dx` / `pop dx`) — EDX is overwritten with `0x534D4150` ('SMAP') on every iteration, corrupting the drive number passed to `int 0x13`
- Add bounds check: cap E820 entries at 128 to prevent buffer overflow toward the boot sector
- Add QEMU interrupt logging (`-d int -D /tmp/qemu.log`) and real-mode stage2 breadcrumb for easier debugging

Closes #1

## Follow-up issues

- #25 — Fix test output corrupting E820 display (`FAIL=` at row 0)
- #26 — E820 display overlaps ASCII art when QEMU returns >5 entries

## Test plan

- [x] `./build_and_run.sh` completes without error
- [x] QEMU screen shows breadcrumbs `?1234` followed by stage2 PM output
- [x] E820 table lists all entries with correct 16-digit hex base/length and type
- [x] No hang or triple fault

🤖 Generated with [Claude Code](https://claude.com/claude-code)